### PR TITLE
Dashboard Campaign Deletion Modal

### DIFF
--- a/ChatRPG/App.razor
+++ b/ChatRPG/App.razor
@@ -1,14 +1,16 @@
 ﻿<CascadingAuthenticationState>
-    <Router AppAssembly="@typeof(App).Assembly">
-        <Found Context="routeData">
-            <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)"/>
-            <FocusOnNavigate RouteData="@routeData" Selector="h1"/>
-        </Found>
-        <NotFound>
-            <PageTitle>Not found</PageTitle>
-            <LayoutView Layout="@typeof(MainLayout)">
-                <p role="alert">Sorry, there's nothing at this address.</p>
-            </LayoutView>
-        </NotFound>
-    </Router>
+    <CascadingBlazoredModal>
+        <Router AppAssembly="@typeof(App).Assembly">
+            <Found Context="routeData">
+                <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)"/>
+                <FocusOnNavigate RouteData="@routeData" Selector="h1"/>
+            </Found>
+            <NotFound>
+                <PageTitle>Not found</PageTitle>
+                <LayoutView Layout="@typeof(MainLayout)">
+                    <p role="alert">Sorry, there's nothing at this address.</p>
+                </LayoutView>
+            </NotFound>
+        </Router>
+    </CascadingBlazoredModal>
 </CascadingAuthenticationState>

--- a/ChatRPG/ChatRPG.csproj
+++ b/ChatRPG/ChatRPG.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Blazored.Modal" Version="7.1.0" />
     <PackageReference Include="MailKit" Version="4.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.12" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.12" />

--- a/ChatRPG/Pages/ConfirmModal.razor
+++ b/ChatRPG/Pages/ConfirmModal.razor
@@ -22,8 +22,8 @@
                 </p>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" @onclick="Close">Close</button>
-                <button type="button" class="btn alert-danger" @onclick="Confirm">Confirm</button>
+                <button type="button" class="btn btn-secondary" @onclick="Close" id="modal-close">Close</button>
+                <button type="button" class="btn alert-danger" @onclick="Confirm" id="modal-confirm">Confirm</button>
             </div>
         </div>
     </div>

--- a/ChatRPG/Pages/ConfirmModal.razor
+++ b/ChatRPG/Pages/ConfirmModal.razor
@@ -1,0 +1,58 @@
+@using ChatRPG.Services
+@using ChatRPG.Data.Models
+
+<div class="modal fade show d-block" tabindex="-1" role="dialog">
+    <div class="modal-backdrop fade show" @onclick="Cancel"></div>
+    <div class="modal-dialog" style="z-index: 1050">
+        <!-- Pop it above the backdrop -->
+        <div class="modal-content custom-gray-bg text-white">
+            <div class="modal-header">
+                <h5 class="modal-title">Delete Campaign?</h5>
+                <button type="button" class="close" aria-label="Close" @onclick="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <p>Do you really want to delete the campaign?</p>
+                <p>
+                    <b>Campaign title:</b> @CampaignToDelete!.Title
+                </p>
+                <p>
+                    <b>Character name:</b> @CampaignToDelete!.Player.Name
+                </p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" @onclick="Close">Close</button>
+                <button type="button" class="btn alert-danger" @onclick="Confirm">Confirm</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+@code {
+
+    [CascadingParameter]
+    BlazoredModalInstance Modal { get; set; } = default!;
+
+    [Parameter]
+    [EditorRequired]
+    public Campaign? CampaignToDelete { get; set; }
+
+    [Inject]
+    private IPersisterService? PersistService { get; set; }
+
+    private async Task Confirm()
+    {
+        if (CampaignToDelete is null)
+        {
+            await Modal.CancelAsync();
+        }
+
+        await PersistService!.DeleteAsync(CampaignToDelete!);
+        await Modal.CloseAsync(ModalResult.Ok(true));
+    }
+
+    private async Task Close() => await Modal.CloseAsync(ModalResult.Ok(false));
+    private async Task Cancel() => await Modal.CancelAsync();
+
+}

--- a/ChatRPG/Pages/UserCampaignOverview.razor
+++ b/ChatRPG/Pages/UserCampaignOverview.razor
@@ -15,7 +15,7 @@
                     <div class="vstack overflow-auto form-text-black mb-1 scrollbar" style="max-height: 500px;" id="your-campaigns">
                         @foreach (CampaignModel campaign in Campaigns)
                         {
-                            <button class="card card-dim mb-2" @onclick='() => LaunchCampaign(campaign.Id)'>
+                            <button class="campaign-button card card-dim mb-2" @onclick='() => LaunchCampaign(campaign.Id)'>
                                 <div class="card-body col-12">
                                     <h5 class="card-title">@campaign.Title</h5>
                                     <h6 class="card-subtitle mb-2 text-muted" style="font-size: 14px;">@campaign.Player.Name</h6>
@@ -23,6 +23,9 @@
                                     <p class="card-text line-clamp text-start">@(campaign.StartScenario ?? "No scenario")</p>
                                     <p class="card-text" style="font-size: 14px;">Started @campaign.StartedOn.ToShortDateString() @campaign.StartedOn.ToShortTimeString()</p>
                                 </div>
+                                <button class="delete-campaign-button rounded" @onclick='() => ShowCampaignDeleteModal(campaign)' @onclick:stopPropagation>
+                                    <i class="bi bi-trash3 text-danger"></i>
+                                </button>
                             </button>
                         }
                     </div>

--- a/ChatRPG/Pages/UserCampaignOverview.razor.cs
+++ b/ChatRPG/Pages/UserCampaignOverview.razor.cs
@@ -1,5 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Security.Authentication;
+using Blazored.Modal;
+using Blazored.Modal.Services;
 using ChatRPG.Data.Models;
 using ChatRPG.Services;
 using Microsoft.AspNetCore.Components;
@@ -31,6 +33,8 @@ public partial class UserCampaignOverview : ComponentBase
     [Inject] private IPersisterService? PersisterService { get; set; }
     [Inject] private ICampaignMediatorService? CampaignMediatorService { get; set; }
     [Inject] private NavigationManager? NavMan { get; set; }
+
+    [CascadingParameter] public IModalService? ConfirmDeleteModal { get; set; }
 
     protected override async Task OnInitializedAsync()
     {
@@ -76,6 +80,25 @@ public partial class UserCampaignOverview : ComponentBase
     {
         CampaignTitle = title;
         StartScenario = scenario;
+        StateHasChanged();
+    }
+
+    private async Task ShowCampaignDeleteModal(Campaign campaign)
+    {
+        IModalReference modal = ConfirmDeleteModal!.Show<ConfirmModal>("Delete Campaign",
+            new ModalParameters().Add(nameof(ConfirmModal.CampaignToDelete), campaign));
+
+        ModalResult shouldDelete = await modal.Result;
+        if (shouldDelete.Confirmed)
+        {
+            await ModalClosed();
+        }
+    }
+
+    private async Task ModalClosed()
+    {
+        Campaigns = await PersisterService!.GetCampaignsForUser(User!);
+        Campaigns.Reverse(); // Reverse to display latest campaign first
         StateHasChanged();
     }
 

--- a/ChatRPG/Pages/_Host.cshtml
+++ b/ChatRPG/Pages/_Host.cshtml
@@ -10,6 +10,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <base href="~/" />
     <link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
     <link href="css/site.css" rel="stylesheet" />
     <link href="ChatRPG.styles.css" rel="stylesheet" />
     <link rel="icon" type="image/png" href="favicon.png"/>

--- a/ChatRPG/Program.cs
+++ b/ChatRPG/Program.cs
@@ -1,3 +1,4 @@
+using Blazored.Modal;
 using ChatRPG.API;
 using ChatRPG.Areas.Identity;
 using ChatRPG.Data;
@@ -22,6 +23,7 @@ builder.Services.AddDefaultIdentity<User>()
     .AddEntityFrameworkStores<ApplicationDbContext>();
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor();
+builder.Services.AddBlazoredModal();
 
 HttpMessageHandlerFactory httpMessageHandlerFactory = new HttpMessageHandlerFactory(configuration);
 builder.Services.AddScoped<AuthenticationStateProvider, RevalidatingIdentityAuthenticationStateProvider<User>>()

--- a/ChatRPG/Services/EfPersisterService.cs
+++ b/ChatRPG/Services/EfPersisterService.cs
@@ -42,6 +42,7 @@ public class EfPersisterService : IPersisterService
         }
     }
 
+    /// <inheritdoc />
     public async Task DeleteAsync(Campaign campaign)
     {
         if (!(await _dbContext.Campaigns.ContainsAsync(campaign)))

--- a/ChatRPG/Services/EfPersisterService.cs
+++ b/ChatRPG/Services/EfPersisterService.cs
@@ -42,6 +42,31 @@ public class EfPersisterService : IPersisterService
         }
     }
 
+    public async Task DeleteAsync(Campaign campaign)
+    {
+        if (!(await _dbContext.Campaigns.ContainsAsync(campaign)))
+        {
+            return;
+        }
+
+        await using IDbContextTransaction transaction = await _dbContext.Database.BeginTransactionAsync();
+        try
+        {
+            int campaignId = campaign.Id;
+            _dbContext.Campaigns.Remove(campaign);
+
+            await _dbContext.SaveChangesAsync();
+            await transaction.CommitAsync();
+            _logger.LogInformation("Deleted campaign with id {Id} successfully", campaignId);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "An error occurred while deleting");
+            await transaction.RollbackAsync();
+            throw;
+        }
+    }
+
     /// <inheritdoc />
     public async Task<Campaign> LoadFromCampaignIdAsync(int campaignId)
     {

--- a/ChatRPG/Services/IPersisterService.cs
+++ b/ChatRPG/Services/IPersisterService.cs
@@ -14,6 +14,12 @@ public interface IPersisterService
     /// <returns>A task representing the asynchronous operation.</returns>
     Task SaveAsync(Campaign campaign);
     /// <summary>
+    /// Deletes the given <paramref name="campaign"/> and all its related entities.
+    /// </summary>
+    /// <param name="campaign">The campaign to delete.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    Task DeleteAsync(Campaign campaign);
+    /// <summary>
     /// Loads the campaign with the given <paramref name="campaignId"/> with all its related entities.
     /// </summary>
     /// <param name="campaignId">Id of the campaign to load.</param>

--- a/ChatRPG/_Imports.razor
+++ b/ChatRPG/_Imports.razor
@@ -6,5 +6,7 @@
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.JSInterop
+@using Blazored.Modal
+@using Blazored.Modal.Services
 @using ChatRPG
 @using ChatRPG.Shared

--- a/ChatRPG/wwwroot/css/site.css
+++ b/ChatRPG/wwwroot/css/site.css
@@ -368,5 +368,12 @@ a, .btn-link {
     right: 0;
     margin-right: 5px;
     margin-bottom: 5px;
-    background: #ececec;
+    background: none;
+    overflow: hidden;
+    outline:none;
+    border:solid 1px black;
+}
+
+.delete-campaign-button:hover {
+    background: #eaeaea;
 }

--- a/ChatRPG/wwwroot/css/site.css
+++ b/ChatRPG/wwwroot/css/site.css
@@ -2,6 +2,7 @@
 
 html, body {
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    height: 100%;
 }
 
 h1:focus {
@@ -10,6 +11,10 @@ h1:focus {
 
 a, .btn-link {
     color: #0071c1;
+}
+
+.page {
+    min-height: 100vh;
 }
 
 .btn-primary {
@@ -180,7 +185,7 @@ a, .btn-link {
 .dashboard-wrapper {
     display: flex;
     flex-direction: column;
-    height: 100vh;
+    height: 100%;
 }
 
 .dashboard-container {
@@ -189,8 +194,7 @@ a, .btn-link {
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    overflow-y: auto;
-    margin-top: -120px;
+    margin-top: -50px;
 }
 
 .title-front {

--- a/ChatRPG/wwwroot/css/site.css
+++ b/ChatRPG/wwwroot/css/site.css
@@ -230,7 +230,6 @@ a, .btn-link {
 }
 
 .card-dim {
-    width: 18rem;
     background: #dcdcdc;
 }
 
@@ -357,4 +356,17 @@ a, .btn-link {
 
 .dashboard-title-container {
     padding-bottom: 60px;
+}
+
+.campaign-button {
+    position: relative;
+}
+
+.delete-campaign-button {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    margin-right: 5px;
+    margin-bottom: 5px;
+    background: #ececec;
 }

--- a/ChatRPGTests/AuthorizedIndexE2ETests.cs
+++ b/ChatRPGTests/AuthorizedIndexE2ETests.cs
@@ -424,6 +424,21 @@ public class AuthorizedIndexE2ETests : IDisposable
         Assert.True(characterNameAlert.Displayed && campaignTitleAlert.Displayed);
     }
 
+    [Fact]
+    public void AuthorizedIndexPage_CustomCampaign_CharacterDescriptionIsEmptyOnInitialization()
+    {
+        // Arrange
+        string expectedCharacterDescription = string.Empty;
+
+        // Act
+        IWebElement? characterDescription =
+            _wait.Until(webDriver => webDriver.FindElement(By.Id("inputCharacterDescription")));
+        string actualCharacterDescription = characterDescription.Text;
+
+        // Assert
+        Assert.Equal(expectedCharacterDescription, actualCharacterDescription);
+    }
+
     public void Dispose()
     {
         E2ETestUtility.Teardown(_driver);

--- a/ChatRPGTests/AuthorizedIndexE2ETests.cs
+++ b/ChatRPGTests/AuthorizedIndexE2ETests.cs
@@ -21,7 +21,7 @@ public class AuthorizedIndexE2ETests : IDisposable
         _wait = new WebDriverWait(_driver, TimeSpan.FromSeconds(10));
 
         // Login and prepare to test Authorized Index
-        Login(_testUsername, _testPassword);
+        E2ETestUtility.Login(_wait, _testUsername, _testPassword);
     }
 
     [Fact]
@@ -116,14 +116,14 @@ public class AuthorizedIndexE2ETests : IDisposable
         // Arranged
         IWebElement? campaignsContainer = _wait.Until(webDriver => webDriver.FindElement(By.Id("your-campaigns")));
         ReadOnlyCollection<IWebElement>? campaigns = campaignsContainer.FindElements(By.ClassName("card"));
-        string expectedAmountOfScenarios = campaigns.Count.ToString();
+        string expectedAmountOfCampaigns = campaigns.Count.ToString();
 
         // Act
         IWebElement? campaignsCounter = _wait.Until(webDriver => webDriver.FindElement(By.Id("campaigns-count")));
-        string actualAmountOfScenarios = Regex.Match(campaignsCounter.Text, @"\d+").Value;
+        string actualAmountOfCampaigns = Regex.Match(campaignsCounter.Text, @"\d+").Value;
 
         // Assert
-        Assert.Equal(expectedAmountOfScenarios, actualAmountOfScenarios);
+        Assert.Equal(expectedAmountOfCampaigns, actualAmountOfCampaigns);
     }
 
     [Fact]
@@ -439,22 +439,146 @@ public class AuthorizedIndexE2ETests : IDisposable
         Assert.Equal(expectedCharacterDescription, actualCharacterDescription);
     }
 
+    [Fact]
+    public void AuthorizedIndexPage_YourCampaigns_DisplaysRemoveCampaignButtonWhenEarlierCampaignExists()
+    {
+        // Arrange
+        E2ETestUtility.CreateTestCampaign(_driver, _wait);
+
+        // Act
+        IWebElement? firstRemoveCampaignButton = _wait.Until(webDriver => webDriver.FindElements(By.ClassName("delete-campaign-button")))[0];
+
+        // Assert
+        Assert.True(firstRemoveCampaignButton.Displayed);
+        E2ETestUtility.RemoveTestCampaign(_driver, _wait);
+    }
+
+    [Fact]
+    public void AuthorizedIndexPage_DeleteCampaignModal_ModalIsDisplayedAfterRemoveCampaignButtonIsClicked()
+    {
+        // Arrange
+        E2ETestUtility.CreateTestCampaign(_driver, _wait);
+
+        // Act
+        _wait.Until(webDriver => webDriver.FindElements(By.ClassName("delete-campaign-button")))[0].Click();
+        Thread.Sleep(200); // wait for modal to load
+        IWebElement? modal = _wait.Until(webDriver => webDriver.FindElement(By.ClassName("modal")));
+
+        // Assert
+        Assert.True(modal.Displayed);
+        E2ETestUtility.RemoveTestCampaign(_driver, _wait);
+    }
+
+    [Fact]
+    public void AuthorizedIndexPage_DeleteCampaignModal_ModalCloseButtonIsDisplayedWhenModalIsActivated()
+    {
+        // Arrange
+        E2ETestUtility.CreateTestCampaign(_driver, _wait);
+
+        // Act
+        _wait.Until(webDriver => webDriver.FindElements(By.ClassName("delete-campaign-button")))[0].Click();
+        Thread.Sleep(200); // wait for modal to load
+        IWebElement? modalCloseButton = _wait.Until(webDriver => webDriver.FindElement(By.Id("modal-close")));
+
+        // Assert
+        Assert.True(modalCloseButton.Displayed);
+        E2ETestUtility.RemoveTestCampaign(_driver, _wait);
+    }
+
+    [Fact]
+    public void AuthorizedIndexPage_DeleteCampaignModal_ModalConfirmButtonIsDisplayedWhenModalIsActivated()
+    {
+        // Arrange
+        E2ETestUtility.CreateTestCampaign(_driver, _wait);
+
+        // Act
+        _wait.Until(webDriver => webDriver.FindElements(By.ClassName("delete-campaign-button")))[0].Click();
+        Thread.Sleep(200); // wait for modal to load
+        IWebElement? modalConfirmButton = _wait.Until(webDriver => webDriver.FindElement(By.Id("modal-confirm")));
+
+        // Assert
+        Assert.True(modalConfirmButton.Displayed);
+        E2ETestUtility.RemoveTestCampaign(_driver, _wait);
+    }
+
+    [Fact]
+    public void AuthorizedIndexPage_DeleteCampaignModal_ModalBodyContainsCorrectCampaignTitle()
+    {
+        // Arrange
+        E2ETestUtility.CreateTestCampaign(_driver, _wait);
+        _wait.Until(webDriver => webDriver.FindElements(By.ClassName("delete-campaign-button")))[0].Click();
+        Thread.Sleep(200); // wait for modal to load
+        string expectedCampaignTitleString = "Campaign title: Test Title";
+
+        // Act
+        IWebElement? modalBody = _wait.Until(webDriver => webDriver.FindElement(By.ClassName("modal-body")));
+
+        // Assert
+        Assert.Contains(expectedCampaignTitleString, modalBody.Text);
+        E2ETestUtility.RemoveTestCampaign(_driver, _wait);
+    }
+
+    [Fact]
+    public void AuthorizedIndexPage_DeleteCampaignModal_ModalBodyContainsCorrectCharacterName()
+    {
+        // Arrange
+        E2ETestUtility.CreateTestCampaign(_driver, _wait);
+        _wait.Until(webDriver => webDriver.FindElements(By.ClassName("delete-campaign-button")))[0].Click();
+        Thread.Sleep(200); // wait for modal to load
+        string expectedCharacterName = "Character name: Test Name";
+
+        // Act
+        IWebElement? modalBody = _wait.Until(webDriver => webDriver.FindElement(By.ClassName("modal-body")));
+
+        // Assert
+        Assert.Contains(expectedCharacterName, modalBody.Text);
+        E2ETestUtility.RemoveTestCampaign(_driver, _wait);
+    }
+
+    [Fact]
+    public void AuthorizedIndexPage_DeleteCampaignModal_CampaignIsDeletedAndRemovedFromCampaignListWhenModalIsConfirmed()
+    {
+        // Arrange
+        E2ETestUtility.CreateTestCampaign(_driver, _wait);
+        IWebElement? campaignsCounterBefore = _wait.Until(webDriver => webDriver.FindElement(By.Id("campaigns-count")));
+        int expectedAmountOfCampaigns = int.Parse(Regex.Match(campaignsCounterBefore.Text, @"\d+").Value) - 1;
+        _wait.Until(webDriver => webDriver.FindElements(By.ClassName("delete-campaign-button")))[0].Click();
+        Thread.Sleep(200); // wait for modal to load
+
+        // Act
+        _wait.Until(webDriver => webDriver.FindElement(By.Id("modal-confirm"))).Click();
+        Thread.Sleep(500); // Wait for page to update
+        IWebElement? campaignsCounterAfter = _wait.Until(webDriver => webDriver.FindElement(By.Id("campaigns-count")));
+        int actualAmountOfCampaigns = int.Parse(Regex.Match(campaignsCounterAfter.Text, @"\d+").Value);
+
+        // Assert
+        Assert.Equal(expectedAmountOfCampaigns, actualAmountOfCampaigns);
+    }
+
+    [Fact]
+    public void AuthorizedIndexPage_DeleteCampaignModal_CampaignIsPreservedInCampaignListWhenModalIsClosed()
+    {
+        // Arrange
+        E2ETestUtility.CreateTestCampaign(_driver, _wait);
+        IWebElement? campaignsCounterBefore = _wait.Until(webDriver => webDriver.FindElement(By.Id("campaigns-count")));
+        int expectedAmountOfCampaigns = int.Parse(Regex.Match(campaignsCounterBefore.Text, @"\d+").Value);
+        _wait.Until(webDriver => webDriver.FindElements(By.ClassName("delete-campaign-button")))[0].Click();
+        Thread.Sleep(200); // wait for modal to load
+
+        // Act
+        _wait.Until(webDriver => webDriver.FindElement(By.Id("modal-close"))).Click();
+        Thread.Sleep(500); // Wait for page to update
+        IWebElement? campaignsCounterAfter = _wait.Until(webDriver => webDriver.FindElement(By.Id("campaigns-count")));
+        int actualAmountOfCampaigns = int.Parse(Regex.Match(campaignsCounterAfter.Text, @"\d+").Value);
+
+        // Assert
+        Assert.Equal(expectedAmountOfCampaigns, actualAmountOfCampaigns);
+    }
+
     public void Dispose()
     {
         E2ETestUtility.Teardown(_driver);
         _driver.Dispose();
-    }
-
-    private void Login(string username, string password)
-    {
-        Thread.Sleep(1000); // wait for Index title animation to finish
-        _wait.Until(webDriver => webDriver.FindElement(By.Id("login-button"))).Click();
-        IWebElement? usernameForm = _wait.Until(webDriver => webDriver.FindElement(By.Id("username-form")));
-        usernameForm.SendKeys(username);
-        IWebElement? passwordForm = _wait.Until(webDriver => webDriver.FindElement(By.Id("password-form")));
-        passwordForm.SendKeys(password);
-        _wait.Until(webDriver => webDriver.FindElement(By.Id("login-submit"))).Submit();
-        Thread.Sleep(500); // wait for page to load fully
     }
 
     public static IEnumerable<object[]> StartScenarioTitles => new List<object[]>

--- a/ChatRPGTests/CampaignE2ETests.cs
+++ b/ChatRPGTests/CampaignE2ETests.cs
@@ -18,12 +18,14 @@ public class CampaignE2ETests : IDisposable
         _driver = E2ETestUtility.Setup("/");
         _wait = new WebDriverWait(_driver, TimeSpan.FromSeconds(10));
 
-        // Login and prepare to test Campaign page
+        // Login, create test campaign and prepare to test Campaign page
         E2ETestUtility.Login(_wait, _testUsername, _testPassword);
+        E2ETestUtility.CreateTestCampaign(_driver, _wait, true);
     }
 
     public void Dispose()
     {
+        E2ETestUtility.RemoveTestCampaign(_driver, _wait);
         E2ETestUtility.Teardown(_driver);
         _driver.Dispose();
     }

--- a/ChatRPGTests/CampaignE2ETests.cs
+++ b/ChatRPGTests/CampaignE2ETests.cs
@@ -19,24 +19,12 @@ public class CampaignE2ETests : IDisposable
         _wait = new WebDriverWait(_driver, TimeSpan.FromSeconds(10));
 
         // Login and prepare to test Campaign page
-        Login(_testUsername, _testPassword);
+        E2ETestUtility.Login(_wait, _testUsername, _testPassword);
     }
 
     public void Dispose()
     {
         E2ETestUtility.Teardown(_driver);
         _driver.Dispose();
-    }
-
-    private void Login(string username, string password)
-    {
-        Thread.Sleep(1000); // wait for Index title animation to finish
-        _wait.Until(webDriver => webDriver.FindElement(By.Id("login-button"))).Click();
-        IWebElement? usernameForm = _wait.Until(webDriver => webDriver.FindElement(By.Id("username-form")));
-        usernameForm.SendKeys(username);
-        IWebElement? passwordForm = _wait.Until(webDriver => webDriver.FindElement(By.Id("password-form")));
-        passwordForm.SendKeys(password);
-        _wait.Until(webDriver => webDriver.FindElement(By.Id("login-submit"))).Submit();
-        Thread.Sleep(500); // wait for page to load fully
     }
 }

--- a/ChatRPGTests/CampaignE2ETests.cs
+++ b/ChatRPGTests/CampaignE2ETests.cs
@@ -1,0 +1,42 @@
+using OpenQA.Selenium;
+using OpenQA.Selenium.Support.UI;
+
+namespace ChatRPGTests;
+
+[Collection("E2E collection")]
+public class CampaignE2ETests : IDisposable
+{
+    private readonly ChatRPGFixture _fixture;
+    private readonly IWebDriver _driver;
+    private readonly WebDriverWait _wait;
+    private readonly string _testUsername = "test";
+    private readonly string _testPassword = "test";
+
+    public CampaignE2ETests(ChatRPGFixture fixture)
+    {
+        _fixture = fixture;
+        _driver = E2ETestUtility.Setup("/");
+        _wait = new WebDriverWait(_driver, TimeSpan.FromSeconds(10));
+
+        // Login and prepare to test Campaign page
+        Login(_testUsername, _testPassword);
+    }
+
+    public void Dispose()
+    {
+        E2ETestUtility.Teardown(_driver);
+        _driver.Dispose();
+    }
+
+    private void Login(string username, string password)
+    {
+        Thread.Sleep(1000); // wait for Index title animation to finish
+        _wait.Until(webDriver => webDriver.FindElement(By.Id("login-button"))).Click();
+        IWebElement? usernameForm = _wait.Until(webDriver => webDriver.FindElement(By.Id("username-form")));
+        usernameForm.SendKeys(username);
+        IWebElement? passwordForm = _wait.Until(webDriver => webDriver.FindElement(By.Id("password-form")));
+        passwordForm.SendKeys(password);
+        _wait.Until(webDriver => webDriver.FindElement(By.Id("login-submit"))).Submit();
+        Thread.Sleep(500); // wait for page to load fully
+    }
+}

--- a/ChatRPGTests/E2ETestUtility.cs
+++ b/ChatRPGTests/E2ETestUtility.cs
@@ -1,5 +1,7 @@
+using System.Collections.ObjectModel;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chrome;
+using OpenQA.Selenium.Support.UI;
 
 namespace ChatRPGTests;
 
@@ -30,5 +32,41 @@ public static class E2ETestUtility
 
         driver.Close();
         driver.Quit();
+    }
+
+    public static void Login(WebDriverWait wait, string username, string password)
+    {
+        Thread.Sleep(1000); // wait for Index title animation to finish
+        wait.Until(webDriver => webDriver.FindElement(By.Id("login-button"))).Click();
+        wait.Until(webDriver => webDriver.FindElement(By.Id("username-form"))).SendKeys(username);
+        wait.Until(webDriver => webDriver.FindElement(By.Id("password-form"))).SendKeys(password);
+        wait.Until(webDriver => webDriver.FindElement(By.Id("login-submit"))).Submit();
+        Thread.Sleep(500); // wait for page to load fully
+    }
+
+    public static void CreateTestCampaign(IWebDriver driver, WebDriverWait wait)
+    {
+        driver.Navigate().GoToUrl("http://localhost:5111/");
+        Thread.Sleep(500);
+        wait.Until(webDriver => webDriver.FindElement(By.Id("inputCampaignTitle"))).SendKeys("Test Title");
+        wait.Until(webDriver => webDriver.FindElement(By.Id("inputCharacterName"))).SendKeys("Test Name");
+        wait.Until(webDriver => webDriver.FindElement(By.Id("inputCharacterDescription"))).SendKeys("Test Description");
+        wait.Until(webDriver => webDriver.FindElement(By.Id("inputCustomStartScenario"))).SendKeys("Test Scenario");
+        wait.Until(webDriver => webDriver.FindElement(By.Id("create-campaign-button"))).Click();
+        Thread.Sleep(200); // Wait for page to load
+        driver.Navigate().GoToUrl("http://localhost:5111/");
+        Thread.Sleep(500);
+    }
+
+    public static void RemoveTestCampaign(IWebDriver driver, WebDriverWait wait)
+    {
+        driver.Navigate().GoToUrl("http://localhost:5111/");
+        Thread.Sleep(500); // Wait for page to load
+        IWebElement? yourCampaignsContainer =
+            wait.Until(webDriver => webDriver.FindElement(By.Id("your-campaigns")));
+        ReadOnlyCollection<IWebElement>? removeButtons = yourCampaignsContainer.FindElements(By.ClassName("delete-campaign-button"));
+        removeButtons[0].Click(); // Remove latest campaign
+        wait.Until(webDriver => webDriver.FindElement(By.Id("modal-confirm"))).Click();
+        Thread.Sleep(200);
     }
 }

--- a/ChatRPGTests/E2ETestUtility.cs
+++ b/ChatRPGTests/E2ETestUtility.cs
@@ -44,7 +44,7 @@ public static class E2ETestUtility
         Thread.Sleep(500); // wait for page to load fully
     }
 
-    public static void CreateTestCampaign(IWebDriver driver, WebDriverWait wait)
+    public static void CreateTestCampaign(IWebDriver driver, WebDriverWait wait, bool goToCampaign = false)
     {
         driver.Navigate().GoToUrl("http://localhost:5111/");
         Thread.Sleep(500);
@@ -54,8 +54,11 @@ public static class E2ETestUtility
         wait.Until(webDriver => webDriver.FindElement(By.Id("inputCustomStartScenario"))).SendKeys("Test Scenario");
         wait.Until(webDriver => webDriver.FindElement(By.Id("create-campaign-button"))).Click();
         Thread.Sleep(200); // Wait for page to load
-        driver.Navigate().GoToUrl("http://localhost:5111/");
-        Thread.Sleep(500);
+        if (!goToCampaign)
+        {
+            driver.Navigate().GoToUrl("http://localhost:5111/");
+            Thread.Sleep(500);
+        }
     }
 
     public static void RemoveTestCampaign(IWebDriver driver, WebDriverWait wait)


### PR DESCRIPTION
***This is a UI enhancement PR and thus should also be reviewed on the webpage in a running state in addition to the source code.***

**Summary of added content:**
- Improvements to the Dashboard page
  - Campaigns can now be deleted with delete button on campaign cards
  - Deletion confirmation modal
  - E2E tests of the modal component


**Relevant files for review:**
- `ChatRPG/Pages/ConfirmModal.razor`
- `ChatRPG/Pages/UserCampaignOverview.razor`
- `ChatRPG/Pages/UserCampaignOverview.razor.cs`
- `ChatRPG/Services/EfPersisterService.cs`

This pull request closes #50