### PR TITLE
Add skull icons to dead characters

### DIFF
--- a/ChatRPG/Pages/CampaignPage.razor
+++ b/ChatRPG/Pages/CampaignPage.razor
@@ -40,7 +40,13 @@
                         <div class="scrollbar" style="max-height: 25vh; overflow-y: auto">
                             @foreach (Character character in _npcList)
                             {
-                                <div class="card card-dim mb-2 text-black text-center">
+                                <div class="card card-dim mb-2 text-black text-center position-relative">
+                                    @if (character.CurrentHealth <= 0)
+                                    {
+                                    <div class="skull-icon">
+                                        <i class="fas fa-skull"></i>
+                                    </div>
+                                    }
                                     <div class="card-body col-12">
                                         <h5 class="card-title" id="character-list-name">@character.Name</h5>
                                         <hr/>

--- a/ChatRPG/Pages/CampaignPage.razor.cs
+++ b/ChatRPG/Pages/CampaignPage.razor.cs
@@ -66,8 +66,7 @@ public partial class CampaignPage
 
         if (_campaign != null)
         {
-            _npcList = _campaign!.Characters.Where(c => !c.IsPlayer).ToList();
-            _npcList.Reverse();
+            _npcList = _campaign!.Characters.Where(c => !c.IsPlayer).OrderByDescending(c => c.Id).ToList();
             _currentLocation = _campaign.Player.Environment;
             _mainCharacter = _campaign.Player;
 

--- a/ChatRPG/Pages/CampaignPage.razor.cs
+++ b/ChatRPG/Pages/CampaignPage.razor.cs
@@ -41,7 +41,7 @@ public partial class CampaignPage
         ? "margin-top: -25px; margin-bottom: -60px;"
         : "margin-top: 20px; margin-bottom: 60px;";
 
-    [Inject] private IJSRuntime? JsRuntime { get; set; }
+    [Inject] private JsInteropService? JsService { get; set; }
     [Inject] private AuthenticationStateProvider? AuthenticationStateProvider { get; set; }
     [Inject] private IPersistenceService? PersistenceService { get; set; }
     [Inject] private ICampaignMediatorService? CampaignMediatorService { get; set; }
@@ -66,9 +66,7 @@ public partial class CampaignPage
 
         if (_campaign != null)
         {
-            _npcList = _campaign!.Characters.Where(c => !c.IsPlayer).OrderByDescending(c => c.Id).ToList();
-            _currentLocation = _campaign.Player.Environment;
-            _mainCharacter = _campaign.Player;
+            UpdateStatsUi();
 
             _conversation = _campaign.Messages.OrderBy(m => m.Timestamp)
                 .Select(OpenAiGptMessage.FromMessage)
@@ -90,9 +88,8 @@ public partial class CampaignPage
     {
         if (firstRender)
         {
-            _scrollJsScript ??= await JsRuntime!.InvokeAsync<IJSObjectReference>("import", "./js/scroll.js");
-            _detectScrollBarJsScript ??=
-                await JsRuntime!.InvokeAsync<IJSObjectReference>("import", "./js/detectScrollBar.js");
+            _scrollJsScript ??= await JsService!.GetScrollModuleAsync();
+            _detectScrollBarJsScript ??= await JsService!.GetDetectScrollBarModuleAsync();
             await ScrollToElement(BottomId); // scroll down to latest message
         }
 

--- a/ChatRPG/Pages/_Host.cshtml
+++ b/ChatRPG/Pages/_Host.cshtml
@@ -11,6 +11,7 @@
     <base href="~/" />
     <link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
     <link rel="stylesheet" href="_content/Radzen.Blazor/css/material-base.css">
     <link href="css/site.css" rel="stylesheet" />
     <link href="ChatRPG.styles.css" rel="stylesheet" />

--- a/ChatRPG/Program.cs
+++ b/ChatRPG/Program.cs
@@ -31,7 +31,8 @@ builder.Services.AddScoped<AuthenticationStateProvider, RevalidatingIdentityAuth
     .AddTransient<IEmailSender, EmailSender>()
     .AddTransient<GameInputHandler>()
     .AddTransient<GameStateManager>()
-    .AddSingleton<ICampaignMediatorService, CampaignMediatorService>();
+    .AddSingleton<ICampaignMediatorService, CampaignMediatorService>()
+    .AddScoped<JsInteropService>();
 
 builder.Services.Configure<IdentityOptions>(options =>
 {

--- a/ChatRPG/Program.cs
+++ b/ChatRPG/Program.cs
@@ -87,7 +87,21 @@ else
 
 app.UseHttpsRedirection();
 
-app.UseStaticFiles();
+if (app.Environment.IsDevelopment())
+{
+    app.UseStaticFiles(new StaticFileOptions
+    {
+        OnPrepareResponse = ctx =>
+        {
+            ctx.Context.Response.Headers.Append("Cache-Control", "no-cache, no-store");
+            ctx.Context.Response.Headers.Append("Expires", "0");
+        }
+    });
+}
+else
+{
+    app.UseStaticFiles();
+}
 
 app.UseRouting();
 

--- a/ChatRPG/Services/EfPersistenceService.cs
+++ b/ChatRPG/Services/EfPersistenceService.cs
@@ -68,6 +68,7 @@ public class EfPersistenceService(ILogger<EfPersistenceService> logger, Applicat
             .Include(campaign => campaign.Messages)
             .Include(campaign => campaign.Environments)
             .Include(campaign => campaign.Characters)
+            .AsSplitQuery()
             .FirstAsync();
     }
 
@@ -77,6 +78,7 @@ public class EfPersistenceService(ILogger<EfPersistenceService> logger, Applicat
         return await dbContext.Campaigns
             .Where(campaign => campaign.User.Equals(user))
             .Include(campaign => campaign.Characters.Where(c => c.IsPlayer))
+            .AsSplitQuery()
             .ToListAsync();
     }
 

--- a/ChatRPG/Services/JsInteropService.cs
+++ b/ChatRPG/Services/JsInteropService.cs
@@ -1,0 +1,27 @@
+using Microsoft.JSInterop;
+
+namespace ChatRPG.Services;
+
+public class JsInteropService(IJSRuntime jsRuntime) : IAsyncDisposable
+{
+    private IJSObjectReference? _scrollModule;
+    private IJSObjectReference? _detectScrollBarModule;
+
+    public async Task<IJSObjectReference> GetScrollModuleAsync()
+    {
+        return _scrollModule ??= await jsRuntime.InvokeAsync<IJSObjectReference>("import", "./js/scroll.js");
+    }
+
+    public async Task<IJSObjectReference> GetDetectScrollBarModuleAsync()
+    {
+        return _detectScrollBarModule ??= await jsRuntime.InvokeAsync<IJSObjectReference>("import", "./js/detectScrollBar.js");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_scrollModule != null)
+        {
+            await _scrollModule.DisposeAsync();
+        }
+    }
+}

--- a/ChatRPG/wwwroot/css/site.css
+++ b/ChatRPG/wwwroot/css/site.css
@@ -435,3 +435,11 @@ div.sticky {
     color: #ffffff;
     font-size: 175%;
 }
+
+.skull-icon {
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    font-size: 1.2rem; /* Adjust icon size */
+    color: #333;
+}


### PR DESCRIPTION
- Adds a skull icon to dead characters in the Stats UI
- Fixed bug where ScrollToElement would fail to complete on firstRender for larger campaigns because a single DB query would take too long
- Use Cache-Busting for CSS resources on development builds

Closes #107 