### PR TITLE
Feature/player portrait

### DIFF
--- a/ChatRPG/Data/Migrations/20250414103828_AddPortraitToCharacter.Designer.cs
+++ b/ChatRPG/Data/Migrations/20250414103828_AddPortraitToCharacter.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ChatRPG.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ChatRPG.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250414103828_AddPortraitToCharacter")]
+    partial class AddPortraitToCharacter
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ChatRPG/Data/Migrations/20250414103828_AddPortraitToCharacter.cs
+++ b/ChatRPG/Data/Migrations/20250414103828_AddPortraitToCharacter.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ChatRPG.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPortraitToCharacter : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<byte[]>(
+                name: "Portrait",
+                table: "Characters",
+                type: "bytea",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Portrait",
+                table: "Characters");
+        }
+    }
+}

--- a/ChatRPG/Data/Models/Character.cs
+++ b/ChatRPG/Data/Models/Character.cs
@@ -36,6 +36,7 @@ public class Character
     public bool IsPlayer { get; private set; }
     public string Name { get; private set; } = null!;
     public string Description { get; set; } = null!;
+    public byte[]? Portrait { get; set; }
     public int MaxHealth { get; private set; }
     public int CurrentHealth { get; private set; }
 

--- a/ChatRPG/Pages/CampaignPage.razor
+++ b/ChatRPG/Pages/CampaignPage.razor
@@ -138,6 +138,15 @@
                     <HealthBar MaxHealth="_mainCharacter?.MaxHealth"
                                CurrentHealth="_mainCharacter?.CurrentHealth"></HealthBar>
                 </div>
+                @if (_mainCharacter?.Portrait != null)
+                {
+                    <div class="mx-4 mt-3">
+                        <h4 class="text-center mb-4">Portrait</h4>
+                        <img src="data:image/png;base64,@Convert.ToBase64String(_mainCharacter.Portrait)"
+                             class="img-fluid rounded"
+                             alt="Portrait of @_mainCharacter.Name" />
+                    </div>
+                }
             </div>
             <!-- RadzenStack fixed to the bottom of the outer div -->
             <div style="position: absolute; bottom: 1rem; left: 0; right: 0; text-align: center;">

--- a/ChatRPG/Pages/UserCampaignOverview.razor.cs
+++ b/ChatRPG/Pages/UserCampaignOverview.razor.cs
@@ -55,6 +55,9 @@ public partial class UserCampaignOverview : ComponentBase
     private VisualizationService? VisualizationService { get; set; }
 
     [Inject]
+    private PortraitGenerator? PortraitGenerator { get; set; }
+
+    [Inject]
     private ICampaignMediatorService? CampaignMediatorService { get; set; }
 
     [Inject]
@@ -128,6 +131,7 @@ public partial class UserCampaignOverview : ComponentBase
             VisualizationService!.VisualizeNarrativeGraphIfEnabled(campaign.NarrativeGraph);
         }
 
+        await PortraitGenerator!.GeneratePortraitAsync(player, campaign.StartScenario!);
         LaunchCampaign(campaign.Id);
     }
 

--- a/ChatRPG/Program.cs
+++ b/ChatRPG/Program.cs
@@ -36,6 +36,7 @@ builder.Services.AddScoped<AuthenticationStateProvider, RevalidatingIdentityAuth
     .AddTransient<ReActScribeAgent>()
     .AddSingleton<ICampaignMediatorService, CampaignMediatorService>()
     .AddScoped<JsInteropService>()
+    .AddScoped<PortraitGenerator>()
     .AddScoped<ScenarioDocumentService>()
     .AddScoped<VisualizationService>();
 

--- a/ChatRPG/Services/PortraitGenerator.cs
+++ b/ChatRPG/Services/PortraitGenerator.cs
@@ -16,7 +16,7 @@ public class PortraitGenerator
         _imageGenerationOptions = new ImageGenerationOptions()
         {
             Quality = GeneratedImageQuality.Standard,
-            Size = GeneratedImageSize.W1024xH1792,
+            Size = GeneratedImageSize.W1024xH1024,
             Style = GeneratedImageStyle.Vivid,
             ResponseFormat = GeneratedImageFormat.Bytes
         };
@@ -26,12 +26,12 @@ public class PortraitGenerator
     public async Task GeneratePortraitAsync(Character character, string startingScenario)
     {
         var prompt = $"""
-                      A portrait of {character.Name.Trim()}, described as {character.Description.Trim()}.
+                      Create a portrait of {character.Name.Trim()}, described as {character.Description.Trim()}.
 
                       The background reflects the atmosphere and setting of this fantasy scenario:
                       {startingScenario.Trim()}
 
-                      Style: highly detailed, cinematic lighting, fantasy digital painting, intricate textures, professional concept art quality.
+                      Style: highly detailed, cinematic lighting, fantasy digital painting, intricate textures, professional concept art quality, no text or text-boxes.
                       """;
 
         var image = await _llm.GenerateImageAsync(prompt, _imageGenerationOptions);

--- a/ChatRPG/Services/PortraitGenerator.cs
+++ b/ChatRPG/Services/PortraitGenerator.cs
@@ -1,0 +1,42 @@
+﻿using ChatRPG.Data.Models;
+using OpenAI.Images;
+
+namespace ChatRPG.Services;
+
+public class PortraitGenerator
+{
+    private readonly ImageClient _llm;
+    private readonly ImageGenerationOptions _imageGenerationOptions;
+    private readonly IPersistenceService _persistenceService;
+
+    public PortraitGenerator(IConfiguration configuration, IPersistenceService persistenceService)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(configuration.GetSection("ApiKeys").GetValue<string>("OpenAI"));
+        _llm = new ImageClient("dall-e-3", configuration.GetSection("ApiKeys").GetValue<string>("OpenAI")!);
+        _imageGenerationOptions = new ImageGenerationOptions()
+        {
+            Quality = GeneratedImageQuality.Standard,
+            Size = GeneratedImageSize.W1024xH1792,
+            Style = GeneratedImageStyle.Vivid,
+            ResponseFormat = GeneratedImageFormat.Bytes
+        };
+        _persistenceService = persistenceService;
+    }
+
+    public async Task GeneratePortraitAsync(Character character, string startingScenario)
+    {
+        var prompt = $"""
+                      A portrait of {character.Name.Trim()}, described as {character.Description.Trim()}.
+
+                      The background reflects the atmosphere and setting of this fantasy scenario:
+                      {startingScenario.Trim()}
+
+                      Style: highly detailed, cinematic lighting, fantasy digital painting, intricate textures, professional concept art quality.
+                      """;
+
+        var image = await _llm.GenerateImageAsync(prompt, _imageGenerationOptions);
+        character.Portrait = image.Value.ImageBytes.ToArray();
+
+        await _persistenceService.SaveAsync(character.Campaign);
+    }
+}

--- a/ChatRPG/Services/PortraitGenerator.cs
+++ b/ChatRPG/Services/PortraitGenerator.cs
@@ -28,10 +28,10 @@ public class PortraitGenerator
         var prompt = $"""
                       Create a portrait of {character.Name.Trim()}, described as {character.Description.Trim()}.
 
-                      The background reflects the atmosphere and setting of this fantasy scenario:
+                      Let the following affect the background atmosphere and setting of this fantasy scenario:
                       {startingScenario.Trim()}
 
-                      Style: highly detailed, cinematic lighting, fantasy digital painting, intricate textures, professional concept art quality, no text or text-boxes.
+                      Style: highly detailed, cinematic lighting, fantasy digital painting, intricate textures, no text or text-boxes.
                       """;
 
         var image = await _imageLlmClient.GenerateImageAsync(prompt, _imageGenerationOptions);

--- a/ChatRPG/Services/PortraitGenerator.cs
+++ b/ChatRPG/Services/PortraitGenerator.cs
@@ -3,6 +3,9 @@ using OpenAI.Images;
 
 namespace ChatRPG.Services;
 
+/// <summary>
+/// Service for generating character portraits using the DALL-E 3 model.
+/// </summary>
 public class PortraitGenerator
 {
     private readonly ImageClient _imageLlmClient;
@@ -23,13 +26,18 @@ public class PortraitGenerator
         _persistenceService = persistenceService;
     }
 
-    public async Task GeneratePortraitAsync(Character character, string startingScenario)
+    /// <summary>
+    /// Generates a portrait of the given character using the DALL-E 3 model.
+    /// </summary>
+    /// <param name="character">The character that will have their portrait generated.</param>
+    /// <param name="atmosphereDescription">The background atmosphere description.</param>
+    public async Task GeneratePortraitAsync(Character character, string atmosphereDescription)
     {
         var prompt = $"""
                       Create a portrait of {character.Name.Trim()}, described as {character.Description.Trim()}.
 
                       Let the following affect the background atmosphere and setting of this fantasy scenario:
-                      {startingScenario.Trim()}
+                      {atmosphereDescription.Trim()}
 
                       Style: highly detailed, cinematic lighting, fantasy digital painting, intricate textures, no text or text-boxes.
                       """;

--- a/ChatRPG/Services/PortraitGenerator.cs
+++ b/ChatRPG/Services/PortraitGenerator.cs
@@ -5,14 +5,14 @@ namespace ChatRPG.Services;
 
 public class PortraitGenerator
 {
-    private readonly ImageClient _llm;
+    private readonly ImageClient _imageLlmClient;
     private readonly ImageGenerationOptions _imageGenerationOptions;
     private readonly IPersistenceService _persistenceService;
 
     public PortraitGenerator(IConfiguration configuration, IPersistenceService persistenceService)
     {
         ArgumentException.ThrowIfNullOrEmpty(configuration.GetSection("ApiKeys").GetValue<string>("OpenAI"));
-        _llm = new ImageClient("dall-e-3", configuration.GetSection("ApiKeys").GetValue<string>("OpenAI")!);
+        _imageLlmClient = new ImageClient("dall-e-3", configuration.GetSection("ApiKeys").GetValue<string>("OpenAI")!);
         _imageGenerationOptions = new ImageGenerationOptions()
         {
             Quality = GeneratedImageQuality.Standard,
@@ -34,7 +34,7 @@ public class PortraitGenerator
                       Style: highly detailed, cinematic lighting, fantasy digital painting, intricate textures, professional concept art quality, no text or text-boxes.
                       """;
 
-        var image = await _llm.GenerateImageAsync(prompt, _imageGenerationOptions);
+        var image = await _imageLlmClient.GenerateImageAsync(prompt, _imageGenerationOptions);
         character.Portrait = image.Value.ImageBytes.ToArray();
 
         await _persistenceService.SaveAsync(character.Campaign);


### PR DESCRIPTION
This pull request introduces a new feature to add character portraits in the ChatRPG application. The changes include modifications to the database schema, updates to the character model, and the addition of a new service for generating portraits using OpenAI's image generation capabilities.

### Database and Model Changes:
* Added a new column `Portrait` to the `Characters` table to store portrait images. (`ChatRPG/Data/Migrations/20250414103828_AddPortraitToCharacter.cs`, `ChatRPG/Data/Migrations/ApplicationDbContextModelSnapshot.cs`) [[1]](diffhunk://#diff-4db10fdef58f25f028907b8a7bbf47741733fc79012c873768312a31dd585b2aR1-R28) [[2]](diffhunk://#diff-052dacf16006b786172bb03cff8c658711ae32f32107283b35dfc766a17d84fbR101-R103)
* Updated the `Character` model to include a `Portrait` property. (`ChatRPG/Data/Models/Character.cs`)

### UI Changes:
* Updated the campaign page to display the character's portrait if available. (`ChatRPG/Pages/CampaignPage.razor`)

### Service and Dependency Injection:
* Introduced a new `PortraitGenerator` service to generate character portraits using OpenAI's image generation API. (`ChatRPG/Services/PortraitGenerator.cs`, `ChatRPG/Program.cs`) [[1]](diffhunk://#diff-c1975052b6f6a2dc9197c9d2fa5affb0db73874030c116f598e4af1f9d161e3cR1-R42) [[2]](diffhunk://#diff-c6c57eb8aef66910ebf71d1d4547e6f91cd3e71df488e20a2cbd8ac95ca80da5R39)
* Injected `PortraitGenerator` into the `UserCampaignOverview` component and used it to generate portraits when creating and starting a campaign. (`ChatRPG/Pages/UserCampaignOverview.razor.cs`) [[1]](diffhunk://#diff-d789ab689b515b51cd6f62f453d9951fd3f0202a41d33ecd6dde99a2006a349cR57-R59) [[2]](diffhunk://#diff-d789ab689b515b51cd6f62f453d9951fd3f0202a41d33ecd6dde99a2006a349cR134)